### PR TITLE
fix: correct test command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ The project is header-only, therefore no build is needed.
 For testing, use "CC=clang bazel test --copt='...' <>" to run the unit tests.
 
 For example:
-* CC=clang bazel test --copt='-msse4.1' ... # x86 host
-* CC=clang bazel test --copt='-mavx2' ... # x86 host
-* CC=clang bazel test --copt='-maltivec' ... # Power host
+* CC=clang bazel test dimsum_test --copt='-msse4.1' ... # x86 host
+* CC=clang bazel test dimsum_test --copt='-mavx2' ... # x86 host
+* CC=clang bazel test dimsum_test --copt='-maltivec' ... # Power host
 
 Cross compilation is a bit tricky, but we found the following working, as long as
 the toolchains support cross compilation:


### PR DESCRIPTION
I was getting this with bazel release 0.5.3-homebrew on mac:

```
❯ CC=clang bazel test --copt='-mavx2'
INFO: Found 0 test targets...
INFO: Elapsed time: 0.225s, Critical Path: 0.00s
ERROR: No test targets were found, yet testing was requested.
```